### PR TITLE
Use scipy.linalg.qr() instead of np.linalg.qr()

### DIFF
--- a/nlft_qsp/numerics/backend_numpy.py
+++ b/nlft_qsp/numerics/backend_numpy.py
@@ -1,5 +1,6 @@
 
 import numpy as np
+import scipy.linalg
 
 
 from numerics.backend import NumericBackend
@@ -131,4 +132,4 @@ class NumpyBackend(NumericBackend):
         return np.linalg.solve(A, b)
     
     def qr_decomp(self, A):
-        return np.linalg.qr(A)
+        return scipy.linalg.qr(A)


### PR DESCRIPTION
On one system, complex256 was selected for numpy. This caused a “TypeError: array type complex256 is unsupported in linalg” in numpy’s `_linalg.py` because np.linalg.qr() doesn’t support such large types. This can be mitigated by using scipy instead.